### PR TITLE
Clarify Exercise use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,24 @@ At Brightline we assign homework to a `Member` in the form of an `ExerciseAssign
 - A member can complete the same `Exercise` multiple times
 - An `ExerciseAssignment` can be completed by setting the `completed_at` date
 - We define `Exercise`s in a YAML file
+
+## How do Exercises work?
+
+We've omitted some lower-level details of Exercises that don't really apply to this scenario,
+such as a detailed UI. You can assume that ExerciseAssignments generally work as follows:
+
+1. A member logs into their account and sees a list of active assignments
+2. They select an assignment and are presented with a multi-step UI for completing it
+3. They fill out several fields and submit the assignment
+4. A Rails controller populates the `completed_at` and `data` columns for the relevant ExerciseAssignment
+
+As a specific example, here's how "Learning to Relax" might work:
+
+1. "Before we start - how are you feeling?" (slider from 1-10 where 1 = very stressed, 10 = very relaxed)
+2. Member completes a guided meditation exercise presented via video
+3. "How are you feeling now?" (slider from 1-10 again)
+
+Then the backend would persist `starting_feeling` and `ending_feeling` in the JSONB `data`
+column on ExerciseAssignment.
+
+Each exercise may collect unique data points, which is why it uses an unstructured JSONB column.

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -1,6 +1,6 @@
 EXERCISE_CONFIG_PATH = Rails.root.join("config", "models", "exercises.yml")
 
-Exercise = Struct.new(:id, :kind, :title, :duration_in_minutes, :url, keyword_init: true) {
+Exercise = Struct.new(:id, :kind, :title, :duration_in_minutes, keyword_init: true) {
   def self.config
     @config ||= YAML.safe_load(ERB.new(File.read(EXERCISE_CONFIG_PATH)).result).symbolize_keys
   end

--- a/config/models/exercises.yml
+++ b/config/models/exercises.yml
@@ -1,45 +1,44 @@
-welcome_to_brightline:
-  title: Welcome to Brightline
-  kind: video
-  url: https://hellobrightline.files.wordpress.com/2020/06/welcome_to_brightline.mov.mp4
-  duration_in_minutes: 2
-self_calming_through_relaxation_handout:
-  title: Self Calming Through Relaxation
-  kind: article
-  url: https://content.hellobrightline.com/wp-content/uploads/2020/11/Self-Calming-Through-Relaxation.pdf
-  duration_in_minutes: 2
-quick_calming_handout:
-  title: Quick Calming
-  kind: article
-  url: https://content.hellobrightline.com/wp-content/uploads/2020/10/Quick-Calming-Parent-Handout.pdf
-  duration_in_minutes: 2
-presenting_a_positive_self_handout:
-  title: Presenting a Postive Self
-  kind: article
-  url: https://content.hellobrightline.com/wp-content/uploads/2020/11/Plans-for-Coping-Parent-Handout.pdf
-  duration_in_minutes: 2
-daily_report_card_handout:
-  title: Daily Report Card
-  kind: article
-  url: https://content.hellobrightline.com/wp-content/uploads/2020/10/Quick-Calming-Parent-Handout.pdf
-  duration_in_minutes: 2
-my_rewards_chart_handout:
-  title: My Rewards Chart
-  kind: article
-  url: https://content.hellobrightline.com/wp-content/uploads/2020/12/MindNest-Rewards-Chart-Template.pdf
-  duration_in_minutes: 2
-tips_to_manage_language_delays:
-  title: 3 tips to help manage your child’s language delays
-  kind: article
-  url: https://content.hellobrightline.com/3-tips-to-help-manage-your-childs-language-delays/
-  duration_in_minutes: 2
-tips_to_reduce_frustration_with_speech:
-  title: 3 tips to help reduce your child's frustration with speech
-  kind: article
-  url: https://content.hellobrightline.com/3-tips-to-help-reduce-your-childs-frustration-with-speech/
-  duration_in_minutes: 2
-tips_to_manage_social_language_challenges:
-  title: 3 tips to help manage your child's social language challenges
-  kind: article
-  url: https://content.hellobrightline.com/3-tips-to-help-manage-your-childs-social-language-challenges/
-  duration_in_minutes: 2
+# NOTE: Assume that Exercises have an associated set of UI components /
+# forms that populate the data + completed_at columns.
+#
+# We didn't provide these in this sample codebase and we won't need to
+# interact with them during the interview. Let's just assume they
+# exist and work as expected.
+#
+# See the README for more details.
+all_about_me:
+  title: All About Me
+  kind: digital_exercise
+  duration_in_minutes: 10
+behavior_observation_chart:
+  title: Behavior Observation Chart
+  kind: digital_exercise
+  duration_in_minutes: 5
+body_map:
+  title: Body Map
+  kind: digital_exercise
+  duration_in_minutes: 10
+learning_to_relax:
+  title: Learning to Relax
+  kind: digital_exercise
+  duration_in_minutes: 5
+making_a_plan:
+  title: Making a Plan
+  kind: digital_exercise
+  duration_in_minutes: 5
+self_esteem_journal:
+  title: Self Esteem Journal
+  kind: digital_exercise
+  duration_in_minutes: 10
+sleep_calculator_kids:
+  title: Sleep calculator (for kids)
+  kind: digital_exercise
+  duration_in_minutes: 5
+sleep_calculator_teens:
+  title: Sleep calculator (for teens)
+  kind: digital_exercise
+  duration_in_minutes: 5
+thinking_feeling_doing:
+  title: Thinking Feeling Doing
+  kind: digital_exercise
+  duration_in_minutes: 5

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -3,13 +3,13 @@ require "rails_helper"
 RSpec.describe Exercise do
   describe ".find" do
     it "returns the exercise with the given id" do
-      exercise = described_class.find(:self_calming_through_relaxation_handout)
-      expect(exercise.id).to eq(:self_calming_through_relaxation_handout)
+      exercise = described_class.find(:all_about_me)
+      expect(exercise.id).to eq(:all_about_me)
     end
 
     it "works with strings and symbols" do
-      expect(described_class.find(:self_calming_through_relaxation_handout))
-        .to eq(described_class.find("self_calming_through_relaxation_handout"))
+      expect(described_class.find(:all_about_me))
+        .to eq(described_class.find("all_about_me"))
     end
   end
 end


### PR DESCRIPTION
When setting up this repo, we copy / pasted a handful of exercises, but we inadvertently chose handouts instead of digital exercises. That can sometimes lead to confusion during the interview since candidates often have questions about what data we might store from a PDF handout assignment.

This PR does 2 things:

1. Swap in sample digital exercises for handouts (and remove the URL column)
2. Fill in some gaps in the PR about how the exercises work in reality since we didn't implement a frontend