### PR TITLE
Update gems that were raising errors during bundle install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@
 !/app/assets/builds/.keep
 
 .byebug_history
+
+# Ignore Jetbrains IDE stuff
+/.idea

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ GEM
       digest
       net-protocol
       timeout
-    nio4r (2.5.8)
+    nio4r (2.7.3)
     nokogiri (1.13.1-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.1-x86_64-darwin)
@@ -250,7 +250,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.2)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86_64-darwin)
     standard (1.12.0)
       rubocop (= 1.29.0)
       rubocop-performance (= 1.13.3)


### PR DESCRIPTION
Attempting to set up this project on my work laptop I ran into issues during the `bundle install` step.  The `sqlite3` and `nio4r` both failed to install with a `Gem::Ext::BuildError: ERROR: Failed to build gem native extension.` error message.

Running `bundle update sqlite3 nio4r` seems to fix it on my dev laptop (an 2020 M1 MacBook Pro).

I also added `/.idea` to the `.gitignore` file to ignore the directory where Rubymine keeps configuration data etc.